### PR TITLE
Add instructions for running unsigned apps on macos to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Who hasn't played the dinosaur game in Chrome when the internet goes down? But h
 TouchBarDino is a macOS app that simulates the dinosaur running game on the Touch Bar. It is written in Swift 3 and uses SpriteKit.
 
 ## How to play it
-* Have the latest MacBook Pro with Touch Bar? Download the compiled game [here](https://github.com/yuhuili/TouchBarDino/raw/master/Compiled/Dino%202016-11-22%2020-23-19/Dino.zip)
+* Have the latest MacBook Pro with Touch Bar? Download the compiled game [here](https://github.com/yuhuili/TouchBarDino/raw/master/Compiled/Dino%202016-11-22%2020-23-19/Dino.zip) Recent versions of macOS block unsigned apps by default, to run TouchBarDino right-click/control-click the .app file and click on Open. This will add a security exception for the app, and in the future you can just double-click it to open.
+Here's the macOS support article about this "feature".
 * No? No worries, clone the repo and open it up in Xcode. Then go to Window->Show Touch Bar
 
 <img src="GitHub/play.gif">

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Who hasn't played the dinosaur game in Chrome when the internet goes down? But h
 TouchBarDino is a macOS app that simulates the dinosaur running game on the Touch Bar. It is written in Swift 3 and uses SpriteKit.
 
 ## How to play it
-* Have the latest MacBook Pro with Touch Bar? Download the compiled game [here](https://github.com/yuhuili/TouchBarDino/raw/master/Compiled/Dino%202016-11-22%2020-23-19/Dino.zip)
-> Recent versions of macOS block unsigned apps by default, to run TouchBarDino right-click/control-click the .app file and click on Open.  This will add a security exception for the app, and in the future you can just double-click it to open.
+* Have the latest MacBook Pro with Touch Bar? Download the compiled game [here](https://github.com/yuhuili/TouchBarDino/raw/master/Compiled/Dino%202016-11-22%2020-23-19/Dino.zip). 
+Recent versions of macOS block unsigned apps by default, to run TouchBarDino right-click/control-click the .app file and click on Open.  This will add a security exception for the app, and in the future you can just double-click it to open.
 * No? No worries, clone the repo and open it up in Xcode. Then go to Window->Show Touch Bar
 
 <img src="GitHub/play.gif">

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Who hasn't played the dinosaur game in Chrome when the internet goes down? But h
 TouchBarDino is a macOS app that simulates the dinosaur running game on the Touch Bar. It is written in Swift 3 and uses SpriteKit.
 
 ## How to play it
-* Have the latest MacBook Pro with Touch Bar? Download the compiled game [here](https://github.com/yuhuili/TouchBarDino/raw/master/Compiled/Dino%202016-11-22%2020-23-19/Dino.zip) Recent versions of macOS block unsigned apps by default, to run TouchBarDino right-click/control-click the .app file and click on Open. This will add a security exception for the app, and in the future you can just double-click it to open.
-Here's the macOS support article about this "feature".
+* Have the latest MacBook Pro with Touch Bar? Download the compiled game [here](https://github.com/yuhuili/TouchBarDino/raw/master/Compiled/Dino%202016-11-22%2020-23-19/Dino.zip)
+> Recent versions of macOS block unsigned apps by default, to run TouchBarDino right-click/control-click the .app file and click on Open.  This will add a security exception for the app, and in the future you can just double-click it to open.
 * No? No worries, clone the repo and open it up in Xcode. Then go to Window->Show Touch Bar
 
 <img src="GitHub/play.gif">


### PR DESCRIPTION
This should make it more obvious on how to run the app for users if they encounter macos errors due to this being an unsigned app